### PR TITLE
ローカルの Debugger からサーバーを立ち上げる時に競合して面倒なので、Docker コンテナでサーバーを立ち上げないようにする

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -12,14 +12,14 @@ services:
       - ./docker/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
     ports:
       - "13306:3306"
-  server:
-    build:
-      context: .
-      dockerfile: ./docker/server/Dockerfile
-    ports:
-      - "8000:8000"
-    depends_on:
-      - db
+  # server:
+  #   build:
+  #     context: .
+  #     dockerfile: ./docker/server/Dockerfile
+  #   ports:
+  #     - "8000:8000"
+  #   depends_on:
+  #     - db
 volumes:
   mysql_data_persist:
     driver: local


### PR DESCRIPTION
Debugger も Docker で立ち上げればいいという話ではあるが、面倒くさい＆今困っていないのでとりあえずローカルで立ち上げることにする